### PR TITLE
Say 'Saved file.rb' when generating to file

### DIFF
--- a/lib/victor/cli/commands/generate.rb
+++ b/lib/victor/cli/commands/generate.rb
@@ -20,6 +20,7 @@ module Victor
 
           if ruby_file
             File.write ruby_file, code
+            say "Saved #{ruby_file}"
           else
             puts code
           end

--- a/lib/victor/cli/version.rb
+++ b/lib/victor/cli/version.rb
@@ -1,5 +1,5 @@
 module Victor
   module CLI
-    VERSION = "0.0.1"
+    VERSION = "0.1.0"
   end
 end

--- a/spec/approvals/cli/generate/save
+++ b/spec/approvals/cli/generate/save
@@ -1,0 +1,1 @@
+Saved spec/tmp/code.rb

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,8 @@ Bundler.require :default, :development
 
 include Victor::CLI
 
+Dir.mkdir 'spec/tmp' unless Dir.exist? 'spec/tmp'
+
 RSpec.configure do |config|
   config.fixtures_path = 'spec/approvals'
 end

--- a/spec/victor-cli/commands/generate_spec.rb
+++ b/spec/victor-cli/commands/generate_spec.rb
@@ -23,11 +23,12 @@ describe "victor generate" do
   end
 
   context "with SVG_FILE RUBY_FILE" do
+    let(:ruby_file) { 'spec/tmp/code.rb' }
+    before { system "rm #{ruby_file}" if File.exist? ruby_file }
+
     it "saves the converted ruby code" do
-      Tempfile.create "ruby-code" do |file|
-        subject.run ["generate", svg_file, file.path]
-        expect(File.read file.path).to match_fixture('cli/generate/ruby-code.rb')
-      end
+      expect { subject.run ["generate", svg_file, ruby_file] }.to output_fixture('cli/generate/save')
+      expect(File.read ruby_file).to match_fixture('cli/generate/ruby-code.rb')
     end
   end
 end

--- a/spec/victor-cli/commands/generate_spec.rb
+++ b/spec/victor-cli/commands/generate_spec.rb
@@ -24,7 +24,7 @@ describe "victor generate" do
 
   context "with SVG_FILE RUBY_FILE" do
     let(:ruby_file) { 'spec/tmp/code.rb' }
-    before { system "rm #{ruby_file}" if File.exist? ruby_file }
+    before { File.unlink ruby_file if File.exist? ruby_file }
 
     it "saves the converted ruby code" do
       expect { subject.run ["generate", svg_file, ruby_file] }.to output_fixture('cli/generate/save')


### PR DESCRIPTION
When saving to file, there was no visible output. This PR fixes it.
In addition, since we want a predictable filename, drop the use of tempfile in the tests, and save to a known path.