### PR TITLE
Improve attribute conversion

### DIFF
--- a/lib/victor/cli.rb
+++ b/lib/victor/cli.rb
@@ -1,5 +1,6 @@
 require 'victor'
 require 'requires'
+requires 'cli/refinements'
 require_relative 'cli/parser'
 require_relative 'cli/svg_source'
 require_relative 'cli/ruby_source'

--- a/lib/victor/cli/refinements/stirng_refinements.rb
+++ b/lib/victor/cli/refinements/stirng_refinements.rb
@@ -2,8 +2,16 @@ module Victor
   module CLI
     module Refinements
       refine String do
-        def formatted_value
-          inspect
+        def format_as_key
+          gsub('-', '_')
+        end
+
+        def format_as_value
+          if to_f.to_s == self or to_i.to_s == self
+            self
+          else
+            %Q["#{self}"]
+          end
         end
       end
     end

--- a/lib/victor/cli/refinements/stirng_refinements.rb
+++ b/lib/victor/cli/refinements/stirng_refinements.rb
@@ -1,0 +1,11 @@
+module Victor
+  module CLI
+    module Refinements
+      refine String do
+        def formatted_value
+          inspect
+        end
+      end
+    end
+  end
+end

--- a/lib/victor/cli/svg_source.rb
+++ b/lib/victor/cli/svg_source.rb
@@ -46,7 +46,7 @@ module Victor
 
       def attrs_to_ruby(attrs)
         attrs.map do |key, value|
-          "#{key.to_sym.inspect[1..-1]}: #{value.formatted_value}"
+          "#{key.format_as_key}: #{value.format_as_value}"
         end.join ', '
       end
 

--- a/lib/victor/cli/svg_source.rb
+++ b/lib/victor/cli/svg_source.rb
@@ -3,6 +3,7 @@ require "rufo"
 module Victor
   module CLI
     class SVGSource
+      using Refinements
       attr_reader :svg_tree, :template
 
       def initialize(svg_tree, template: nil)
@@ -38,14 +39,15 @@ module Victor
       end
 
       def nodes_to_ruby(nodes)
-        nodes.map(&method(:code_for_node)).join("\n")
+        nodes.map do |node|
+          code_for_node node
+        end.join "\n"
       end
 
       def attrs_to_ruby(attrs)
-        attrs.reduce([]) do |acc, (k, v)|
-          acc << "#{k.to_sym.inspect[1..-1]}: #{v.inspect}"
-          acc
-        end.join(",")
+        attrs.map do |key, value|
+          "#{key.to_sym.inspect[1..-1]}: #{value.formatted_value}"
+        end.join ', '
       end
 
       def root_to_ruby(node)

--- a/spec/approvals/cli/to-ruby/ruby-code.rb
+++ b/spec/approvals/cli/to-ruby/ruby-code.rb
@@ -1,13 +1,13 @@
 # Render this template by running 'victor to-svg FILE'
 
-setup width: "140", height: "100", style: "background:#ddd"
+setup width: 140, height: 100, style: "background:#ddd"
 
 build do
-  rect x: "10", y: "10", width: "120", height: "80", rx: "10", fill: "#666"
-  circle cx: "50", cy: "50", r: "30", fill: "yellow"
-  circle cx: "58", cy: "32", r: "4", fill: "black"
+  rect x: 10, y: 10, width: 120, height: 80, rx: 10, fill: "#666"
+  circle cx: 50, cy: 50, r: 30, fill: "yellow"
+  circle cx: 58, cy: 32, r: 4, fill: "black"
   polygon points: "45,50 80,30 80,70", fill: "#666"
-  circle cx: "80", cy: "50", r: "4", fill: "yellow"
-  circle cx: "98", cy: "50", r: "4", fill: "yellow"
-  circle cx: "116", cy: "50", r: "4", fill: "yellow"
+  circle cx: 80, cy: 50, r: 4, fill: "yellow"
+  circle cx: 98, cy: 50, r: 4, fill: "yellow"
+  circle cx: 116, cy: 50, r: 4, fill: "yellow"
 end

--- a/spec/approvals/cli/to-ruby/template-dsl
+++ b/spec/approvals/cli/to-ruby/template-dsl
@@ -2,16 +2,16 @@
 
 require "victor/script"
 
-setup width: "140", height: "100", style: "background:#ddd"
+setup width: 140, height: 100, style: "background:#ddd"
 
 build do
-  rect x: "10", y: "10", width: "120", height: "80", rx: "10", fill: "#666"
-  circle cx: "50", cy: "50", r: "30", fill: "yellow"
-  circle cx: "58", cy: "32", r: "4", fill: "black"
+  rect x: 10, y: 10, width: 120, height: 80, rx: 10, fill: "#666"
+  circle cx: 50, cy: 50, r: 30, fill: "yellow"
+  circle cx: 58, cy: 32, r: 4, fill: "black"
   polygon points: "45,50 80,30 80,70", fill: "#666"
-  circle cx: "80", cy: "50", r: "4", fill: "yellow"
-  circle cx: "98", cy: "50", r: "4", fill: "yellow"
-  circle cx: "116", cy: "50", r: "4", fill: "yellow"
+  circle cx: 80, cy: 50, r: 4, fill: "yellow"
+  circle cx: 98, cy: 50, r: 4, fill: "yellow"
+  circle cx: 116, cy: 50, r: 4, fill: "yellow"
 end
 
 puts render

--- a/spec/approvals/svg_source/basic.rb
+++ b/spec/approvals/svg_source/basic.rb
@@ -3,5 +3,5 @@
 setup a: "b"
 
 build do
-  rect x: "10"
+  rect x: 10
 end

--- a/spec/approvals/svg_source/dsl-template.rb
+++ b/spec/approvals/svg_source/dsl-template.rb
@@ -5,7 +5,7 @@ require "victor/script"
 setup a: "b"
 
 build do
-  rect x: "10"
+  rect x: 10
 end
 
 puts render

--- a/spec/approvals/svg_source/nested-nodes.rb
+++ b/spec/approvals/svg_source/nested-nodes.rb
@@ -1,3 +1,3 @@
 g a: "b" do
-  rect x: "10"
+  rect x: 10
 end

--- a/spec/approvals/svg_source/standalone-template.rb
+++ b/spec/approvals/svg_source/standalone-template.rb
@@ -4,7 +4,7 @@ require "victor"
 
 svg = Victor::SVG.new a: "b"
 svg.build do
-  rect x: "10"
+  rect x: 10
 end
 
 svg.save "generated"

--- a/spec/approvals/svg_source/string-input.rb
+++ b/spec/approvals/svg_source/string-input.rb
@@ -4,6 +4,6 @@ setup
 
 build do
   g do
-    rect x: "10"
+    rect x: 10
   end
 end

--- a/spec/victor-cli/refinements/string_refinements_spec.rb
+++ b/spec/victor-cli/refinements/string_refinements_spec.rb
@@ -1,0 +1,25 @@
+require "spec_helper"
+
+describe String do
+  using Refinements
+
+  describe "#format_as_key" do
+    it "converts hyphens to underscores" do
+      expect("font-size".format_as_key).to eq "font_size"
+    end
+  end
+
+  describe '#format_as_value' do
+    it "adds quotes to non numeric values" do
+      expect("#123456".format_as_value).to eq %q["#123456"]
+    end
+
+    it "does not add quotes to integer values" do
+      expect("123".format_as_value).to eq "123"
+    end
+
+    it "does not add quotes to float values" do
+      expect("12.3".format_as_value).to eq "12.3"
+    end
+  end
+end


### PR DESCRIPTION
- Add string refinements, to handle the conversion of attribute keys and values in an isolated place
- Improve conversion of attribute keys and values - closes #13 
- Refactor `SVGSource#nodes_to_ruby` and `#attrs_to_ruby` for better readability